### PR TITLE
Fix a small typo into README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class ProjectPresenter < Showcase::Presenter
   # automatically wraps the attribute into an AdminPresenter
   presents :person, with: AdminPresenter
 
-  # expects project.task to return an enumerable. automatically wraps each task
+  # expects project.tasks to return an enumerable. automatically wraps each task
   # in a TaskPresenter presenter
   presents_collection :tasks
 


### PR DESCRIPTION
It just fixes a small typo. Thanks for this useful gem! :+1: 